### PR TITLE
fix: re-declare server-named queues on channel restore

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -69,6 +69,16 @@ open class RobustAMQPChannel(
     private var declaredQos: DeclaredQos? = null
     internal val declaredExchanges = mutableMapOf<String, DeclaredExchange>()
     internal val declaredQueues = mutableMapOf<String, DeclaredQueue>()
+
+    // Queues declared with an empty name are *channel-scoped*: the broker generates the name, ties the queue's
+    // lifetime to this channel, and mints a different name on every declare. They are therefore tracked apart
+    // from `declaredQueues` and re-declared on every restore regardless of `restoreTopology`. That flag is
+    // about the broker topology the user owns, whereas these queues are part of the channel's own state and
+    // simply cease to exist when it closes. Without re-declaring them, the bindings and consumers recorded
+    // against the previous generated name target a queue that is gone, the broker answers `not_found`, and the
+    // freshly reopened channel is closed again. Keyed by the *broker-assigned* name so bindings and consumers,
+    // which only ever saw that name, can be retargeted after the re-declare.
+    internal val serverNamedQueues = mutableMapOf<String, DeclaredQueue>()
     internal val boundExchanges = mutableMapOf<Triple<String, String, String>, BoundExchange>()
     internal val boundQueues = mutableMapOf<Triple<String, String, String>, BoundQueue>()
     internal val consumedQueues = mutableMapOf<Pair<String, String>, ConsumedQueue>()
@@ -116,12 +126,17 @@ open class RobustAMQPChannel(
                 if (txModeRequested) txSelect()
 
                 declaredQos?.let { basicQos(it) }
+
+                // Channel-scoped queues have to come back before anything that references them; this also
+                // retargets their bindings and consumers onto the names the broker has just handed out.
+                restoreServerNamedQueues()
+
                 if (restoreTopology) {
                     declaredExchanges.values.forEach { exchangeDeclare(it) }
                     declaredQueues.values.forEach { queueDeclare(it) }
                     boundExchanges.values.forEach { exchangeBind(it) }
-                    boundQueues.values.forEach { queueBind(it) }
                 }
+                restoreQueueBindings()
 
                 // Snapshot the list and clear the map before iterating:
                 // basicConsume() will re-populate consumedQueues with the broker-assigned consumer tag,
@@ -165,6 +180,53 @@ open class RobustAMQPChannel(
         } catch (e: Exception) {
             restoreCompleted.completeExceptionally(e)
             throw e
+        }
+    }
+
+    /**
+     * Re-declares the channel-scoped server-named queues, retargeting their bindings and consumers onto the
+     * name the broker assigns now, which differs from the one it assigned before the close.
+     */
+    private suspend fun restoreServerNamedQueues() {
+        if (serverNamedQueues.isEmpty()) return
+        // Iterate over a snapshot: queueDeclare() re-populates the live map under the new name. Each queue is
+        // retargeted as soon as its declare succeeds, so the bookkeeping never holds a name the broker no
+        // longer knows, even if a later declare throws and the restore is retried on a fresh connection.
+        serverNamedQueues.toMap().forEach { (previousName, declaredQueue) ->
+            val currentName = queueDeclare(declaredQueue).queueName
+            if (currentName == previousName) return@forEach
+            serverNamedQueues.remove(previousName)
+            retargetQueue(previousName, currentName)
+        }
+    }
+
+    /**
+     * Points every recorded binding and consumer of [previousName] at [currentName], re-keying them so that
+     * later lookups and restores see only the name the broker currently serves.
+     */
+    private fun retargetQueue(previousName: String, currentName: String) {
+        boundQueues.filterValues { it.queue == previousName }.forEach { (previousKey, boundQueue) ->
+            boundQueues.remove(previousKey)
+            boundQueues[Triple(currentName, boundQueue.exchange, boundQueue.routingKey)] =
+                boundQueue.copy(queue = currentName)
+        }
+        consumedQueues.filterKeys { it.first == previousName }.forEach { (previousKey, consumedQueue) ->
+            consumedQueues.remove(previousKey)
+            consumedQueues[Pair(currentName, previousKey.second)] = consumedQueue.copy(queue = currentName)
+        }
+    }
+
+    /**
+     * Replays the recorded queue bindings, which [restoreServerNamedQueues] has already retargeted onto the
+     * current names. When [restoreTopology] is disabled only the server-named bindings are replayed: they
+     * belong to the channel's own lifecycle rather than to the topology the user asked us to leave alone.
+     */
+    private suspend fun restoreQueueBindings() {
+        if (boundQueues.isEmpty()) return
+        // Names are already current here, so queueBind() rewrites each entry under its own key.
+        boundQueues.values.toList().forEach { boundQueue ->
+            if (!restoreTopology && boundQueue.queue !in serverNamedQueues) return@forEach
+            queueBind(boundQueue)
         }
     }
 
@@ -277,13 +339,24 @@ open class RobustAMQPChannel(
         arguments: Table,
     ): AMQPResponse.Channel.Queue.Declared {
         return super.queueDeclare(name, durable, exclusive, autoDelete, arguments).also {
-            if (restoreTopology) declaredQueues[name] = DeclaredQueue(
+            val declaredQueue = DeclaredQueue(
                 name = name,
                 durable = durable,
                 exclusive = exclusive,
                 autoDelete = autoDelete,
                 arguments = arguments
             )
+            // Keep the empty requested name in the spec so the re-declare asks for a new server-generated one,
+            // but key the entry by the assigned name, which is all the bindings and consumers ever saw.
+            // The predicate is deliberately broad: an exclusive queue is scoped to the connection and an
+            // auto-delete one only goes when its last consumer leaves, so re-declaring can leave the previous
+            // queue behind. An orphan queue is a far better outcome than a channel that never recovers.
+            if (name.isEmpty() && (exclusive || autoDelete)) serverNamedQueues[it.queueName] = declaredQueue
+            // Anything else keeps the existing behaviour, including a server-named queue that is durable and
+            // neither exclusive nor auto-delete. Such a queue does outlive its channel, so replaying the empty
+            // name declares a new one on every restore, but recording the assigned name instead is not an
+            // option: the broker reserves the `amq.*` prefix and answers ACCESS_REFUSED to an explicit declare.
+            else if (restoreTopology) declaredQueues[name] = declaredQueue
         }
     }
 
@@ -294,6 +367,7 @@ open class RobustAMQPChannel(
     ): AMQPResponse.Channel.Queue.Deleted {
         return super.queueDelete(name, ifUnused, ifEmpty).also {
             declaredQueues.remove(name)
+            serverNamedQueues.remove(name)
         }
     }
 
@@ -304,12 +378,16 @@ open class RobustAMQPChannel(
         arguments: Table,
     ): AMQPResponse.Channel.Queue.Bound {
         return super.queueBind(queue, exchange, routingKey, arguments).also {
-            if (restoreTopology) boundQueues[Triple(queue, exchange, routingKey)] = BoundQueue(
-                queue = queue,
-                exchange = exchange,
-                routingKey = routingKey,
-                arguments = arguments
-            )
+            // Bindings onto a server-named queue are tracked even without restoreTopology: the queue is
+            // re-declared on every restore, so its bindings have to be replayed or it receives nothing.
+            if (restoreTopology || queue in serverNamedQueues) {
+                boundQueues[Triple(queue, exchange, routingKey)] = BoundQueue(
+                    queue = queue,
+                    exchange = exchange,
+                    routingKey = routingKey,
+                    arguments = arguments
+                )
+            }
         }
     }
 

--- a/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/ServerNamedQueueRestoreTest.kt
+++ b/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/ServerNamedQueueRestoreTest.kt
@@ -1,0 +1,220 @@
+package dev.kourier.amqp.robust
+
+import dev.kourier.amqp.AMQPException
+import dev.kourier.amqp.BuiltinExchangeType
+import dev.kourier.amqp.channel.AMQPChannel
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+/**
+ * Regression tests for consumers attached to **server-named** queues (the no-arg [AMQPChannel.queueDeclare],
+ * which declares an exclusive, auto-delete, non-durable queue whose name the broker generates).
+ *
+ * Such a queue is *channel-scoped*: the broker deletes it as soon as the channel that declared it goes away.
+ * So when the broker closes a channel (e.g. `consumer_timeout` firing on an unacked delivery), restoring the
+ * consumer requires re-declaring the queue and re-binding it, and the broker hands back a **new** name.
+ *
+ * Before the fix, [RobustAMQPChannel.restore] re-issued `basic.consume` with the *old* generated name:
+ *  - with `restoreTopology = false` the queue was never re-declared at all;
+ *  - with `restoreTopology = true` it was re-declared under the *requested* name `""`, so the broker minted a
+ *    fresh name while `consumedQueues` still held the stale one.
+ *
+ * Both paths made the broker answer `not_found`, which closed the channel again. Because that close is itself
+ * a broker close, the channel was left permanently unusable until the process restarted.
+ */
+class ServerNamedQueueRestoreTest {
+
+    private suspend fun AMQPChannel.closeByBreaking() =
+        assertFailsWith<AMQPException.ChannelClosed> {
+            exchangeDeclare(
+                "will-fail",
+                "nonexistent-type",
+                durable = true,
+                autoDelete = false,
+                internal = false,
+                arguments = emptyMap()
+            )
+        }
+
+    /**
+     * `restoreTopology = false` with a server-named reply queue bound to a topic exchange and consumed on the
+     * very channel that declared it. This is the common request/reply setup.
+     */
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testServerNamedQueueConsumerRestoredWithoutTopologyRestore() = runTest {
+        withConnection({ server { restoreTopology = false } }) { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-server-named-no-topology-${Uuid.random()}"
+            val routingKey = "test.server.named"
+
+            channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, durable = false)
+
+            val queueName = channel.queueDeclare().queueName
+            channel.queueBind(queueName, exchange, routingKey)
+            val deliveries = channel.basicConsume(queue = queueName, noAck = true)
+
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            reopenEvent.await()
+
+            // The consumer must still be attached after the restore.
+            assertFalse(deliveries.isClosedForReceive, "Consumer was cancelled by the restore")
+
+            channel.basicPublish("after-restore".toByteArray(), exchange, routingKey)
+            val delivery = withTimeout(5.seconds) { deliveries.receive() }
+            assertEquals("after-restore", delivery.message.body.decodeToString())
+
+            channel.exchangeDelete(exchange)
+            channel.close()
+        }
+    }
+
+    /**
+     * Same scenario with `restoreTopology = true`. The queue *is* re-declared here, but under the requested
+     * name `""`, so the broker generates a different name than the one the consumer was recorded against.
+     */
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testServerNamedQueueConsumerRestoredWithTopologyRestore() = runTest {
+        withConnection({ server { restoreTopology = true } }) { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-server-named-topology-${Uuid.random()}"
+            val routingKey = "test.server.named"
+
+            channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, durable = false)
+
+            val queueName = channel.queueDeclare().queueName
+            channel.queueBind(queueName, exchange, routingKey)
+            val deliveries = channel.basicConsume(queue = queueName, noAck = true)
+
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            reopenEvent.await()
+
+            assertFalse(deliveries.isClosedForReceive, "Consumer was cancelled by the restore")
+
+            channel.basicPublish("after-restore".toByteArray(), exchange, routingKey)
+            val delivery = withTimeout(5.seconds) { deliveries.receive() }
+            assertEquals("after-restore", delivery.message.body.decodeToString())
+
+            channel.exchangeDelete(exchange)
+            channel.close()
+        }
+    }
+
+    /**
+     * The broker mints a new name on every re-declare, so the bookkeeping has to be retargeted each time
+     * rather than only on the first restore. A second close must be survived just as well as the first.
+     */
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testServerNamedQueueConsumerRestoredAcrossConsecutiveBrokerCloses() = runTest {
+        withConnection({ server { restoreTopology = false } }) { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-server-named-twice-${Uuid.random()}"
+            val routingKey = "test.server.named"
+
+            channel.exchangeDeclare(exchange, BuiltinExchangeType.TOPIC, durable = false)
+
+            val queueName = channel.queueDeclare().queueName
+            channel.queueBind(queueName, exchange, routingKey)
+            val deliveries = channel.basicConsume(queue = queueName, noAck = true)
+
+            repeat(2) { round ->
+                val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+                channel.closeByBreaking()
+                reopenEvent.await()
+
+                assertFalse(deliveries.isClosedForReceive, "Consumer was cancelled by restore #${round + 1}")
+
+                channel.basicPublish("round-$round".toByteArray(), exchange, routingKey)
+                val delivery = withTimeout(5.seconds) { deliveries.receive() }
+                assertEquals("round-$round", delivery.message.body.decodeToString())
+            }
+
+            channel.exchangeDelete(exchange)
+            channel.close()
+        }
+    }
+
+    /**
+     * A server-named queue that is neither exclusive nor auto-delete outlives its channel, so it is ordinary
+     * topology rather than channel-scoped state and must not be tracked as the latter.
+     *
+     * The restore is exercised on purpose: the broker reserves the `amq.*` prefix, so re-declaring such a
+     * queue under the name it assigned draws `ACCESS_REFUSED` and kills the channel for good. The recorded
+     * name has to stay the empty one the caller asked for.
+     */
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testDurableServerNamedQueueIsNotTrackedAsChannelScoped() = runTest {
+        withConnection({ server { restoreTopology = true } }) { connection ->
+            val channel = connection.openChannel() as RobustAMQPChannel
+
+            val queueName = channel
+                .queueDeclare("", durable = false, exclusive = false, autoDelete = false)
+                .queueName
+
+            assertTrue(
+                channel.serverNamedQueues.isEmpty(),
+                "A queue that survives its channel must not be tracked as channel-scoped"
+            )
+
+            // The restore below re-declares this one under the empty name and so leaves an orphan behind.
+            // That is pre-existing behaviour, unrelated to what this test guards, and the queue is transient.
+
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            reopenEvent.await()
+
+            // The channel must have survived the restore rather than tripping over a reserved queue name.
+            val probe = "test-probe-${Uuid.random()}"
+            channel.queueDeclare(probe, durable = false, exclusive = true, autoDelete = true)
+            channel.queueDelete(probe)
+
+            channel.queueDelete(queueName)
+            channel.close()
+        }
+    }
+
+    /**
+     * The channel must stay usable after restoring a server-named consumer. Without the fix the `not_found`
+     * raised during the restore closes the channel a second time, and since that is itself a broker close the
+     * channel never recovers: every later operation throws [AMQPException.ChannelClosed] for the lifetime of
+     * the process.
+     */
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testChannelStaysUsableAfterServerNamedQueueRestore() = runTest {
+        withConnection({ server { restoreTopology = false } }) { connection ->
+            val channel = connection.openChannel()
+
+            val queueName = channel.queueDeclare().queueName
+            channel.basicConsume(queue = queueName, noAck = true)
+
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            reopenEvent.await()
+
+            // A plain operation on the restored channel must succeed rather than throw ChannelClosed.
+            val probe = "test-probe-${Uuid.random()}"
+            channel.queueDeclare(probe, durable = false, exclusive = true, autoDelete = true)
+            channel.queueDelete(probe)
+
+            channel.close()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A consumer attached to a **server-named** queue does not survive a broker-initiated channel close.

The no-arg `queueDeclare()` asks the broker for an exclusive, auto-delete queue and lets it generate the name (`amq.gen-*`). Such a queue is *channel-scoped*: the broker deletes it as soon as the declaring channel goes away, and hands out a **different** name on the next declare.

`RobustAMQPChannel.restore()` did not account for that. It replayed `basic.consume` (and, with `restoreTopology = true`, `queue.bind`) using the name recorded before the close:

- with `restoreTopology = false` the queue was never re-declared at all;
- with `restoreTopology = true` it *was* re-declared, but under the requested name `""`, so the broker minted a fresh name while `consumedQueues` still held the stale one.

Either way the broker answers `404 NOT_FOUND`, which closes the channel again. Since that is itself a broker close, the restore machinery re-triggers and fails identically, so the channel never recovers for the rest of the process lifetime.

Observed frames on the current `main`:

```
Declare(queueName=, exclusive=true, autoDelete=true)
  -> DeclareOk(queueName=amq.gen-g5vPHRsPMiIQKqi1QkwqsA)   <- new name
Bind(queueName=amq.gen-rHTaNLtZ6R_s5hRoYgOtoA, ...)        <- stale name
  -> Close(replyCode=404, NOT_FOUND - no queue 'amq.gen-rHTaNLtZ6R_s5hRoYgOtoA')
```

This is easy to hit in production: any `consumer_timeout` firing on an unacked delivery closes the channel, and a request/reply setup built on a server-named reply queue is left permanently broken until the process restarts.

It is worth noting that #33 reported this very `precondition_failed` frame. The fix at the time made the restore *trigger*; the server-named case was never covered, so since then the restore fires and fails immediately.

## Fix

Server-named queues are now tracked separately from `declaredQueues`, keyed by the name the broker assigned, and re-declared on **every** restore regardless of `restoreTopology`. The rationale for ignoring the flag: `restoreTopology` is about the broker topology the user owns and may not want us to touch, whereas these queues are part of the channel's own state and simply cease to exist when it closes. Leaving them out does not preserve anything, it just breaks the channel.

After each successful re-declare, the recorded bindings and consumers of that queue are retargeted onto the new name in place, keys included. Doing it eagerly (rather than collecting a rename map and applying it at the end of `restore()`) keeps the bookkeeping crash-consistent: if a later declare throws and the restore is retried on a fresh connection, no map is left pointing at a name the broker no longer knows.

Bindings onto a server-named queue are also recorded when `restoreTopology` is disabled, since the queue is recreated on every restore and would otherwise come back with no bindings and receive nothing.

Users who do not declare server-named queues are unaffected: `serverNamedQueues` stays empty, `restoreServerNamedQueues()` returns immediately, and `restoreQueueBindings()` emits exactly the frames the previous `boundQueues.values.forEach { queueBind(it) }` emitted.

The predicate for "channel-scoped" is `exclusive || autoDelete`, deliberately broad. An exclusive queue is scoped to the connection and an auto-delete one only goes when its last consumer leaves, so re-declaring on a channel-only restore can leave the previous queue behind. That orphan is a much better outcome than a channel that never recovers, and the comment in the code says so rather than pretending the case does not exist.

A server-named queue that is neither exclusive nor auto-delete outlives its channel and keeps the existing handling, untouched.

## Tests

`ServerNamedQueueRestoreTest` covers, against a real broker:

- consumer restored across a broker close with `restoreTopology = false`;
- same with `restoreTopology = true`;
- **two consecutive** broker closes, since the broker mints a new name each time and the bookkeeping has to be retargeted on every restore rather than only the first;
- the channel stays usable afterwards, which is the property that actually breaks in production;
- a server-named queue that is neither exclusive nor auto-delete is *not* treated as channel-scoped, and the channel survives a restore with one around.

They fail on `main` and pass with the fix. Full suite green: 32 tests in `amqp-client-robust`, 77 in `amqp-client`. `detekt` reports nothing new (the findings on `RobustAMQPChannel.kt` predate this change).

## Notes for reviewers

Three adjacent issues were noticed while working on this and are deliberately **not** addressed here, to keep the change reviewable:

- With `restoreTopology` enabled, a server-named queue that is neither exclusive nor auto-delete is recorded as `declaredQueues[""]`, so each restore replays a declare with an empty name and mints a brand new queue. I tried recording the assigned name instead and that is a dead end: the broker reserves the `amq.*` prefix and answers `403 ACCESS_REFUSED` to an explicit declare, which kills the channel outright. A real fix probably needs a passive declare or an explicit "do not restore this" marker, so I left `main`'s behaviour alone.

- `basicCancel` (`RobustAMQPChannel.kt`) looks the entry up by `it.value.consumerTag`, which is the *requested* tag and therefore `""` for broker-assigned consumers, so the lookup misses and the entry is never removed. With this fix in place a cancelled consumer on a server-named queue can be resurrected by a later restore. Happy to fix it here or in a follow-up, your call.
- `queueDelete` removes the queue from `declaredQueues` / `serverNamedQueues` but leaves the matching `boundQueues` and `consumedQueues` entries behind.
