### PR TITLE
feat: add no-wait variants for the methods that support it

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -525,4 +525,107 @@ open class RobustAMQPChannel(
         return super.txSelect().also { txModeRequested = true }
     }
 
+    // No-wait variants record exactly what their awaiting counterparts record. Without this, topology
+    // declared through them would be missing from a restore and silently disappear on the first
+    // reconnect. Restore itself keeps using the awaiting variants, since it has no one to report to.
+
+    override suspend fun exchangeDeclareNoWait(
+        name: String,
+        type: String,
+        durable: Boolean,
+        autoDelete: Boolean,
+        internal: Boolean,
+        arguments: Table,
+    ) {
+        super.exchangeDeclareNoWait(name, type, durable, autoDelete, internal, arguments)
+        if (!internal && restoreTopology) declaredExchanges[name] = DeclaredExchange(
+            name = name,
+            type = type,
+            durable = durable,
+            autoDelete = autoDelete,
+            internal = internal,
+            arguments = arguments
+        )
+    }
+
+    override suspend fun exchangeDeleteNoWait(name: String, ifUnused: Boolean) {
+        super.exchangeDeleteNoWait(name, ifUnused)
+        declaredExchanges.remove(name)
+    }
+
+    override suspend fun exchangeBindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: Table,
+    ) {
+        super.exchangeBindNoWait(destination, source, routingKey, arguments)
+        if (restoreTopology) boundExchanges[Triple(destination, source, routingKey)] = BoundExchange(
+            destination = destination,
+            source = source,
+            routingKey = routingKey,
+            arguments = arguments
+        )
+    }
+
+    override suspend fun exchangeUnbindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: Table,
+    ) {
+        super.exchangeUnbindNoWait(destination, source, routingKey, arguments)
+        boundExchanges.remove(Triple(destination, source, routingKey))
+    }
+
+    override suspend fun queueDeclareNoWait(
+        name: String,
+        durable: Boolean,
+        exclusive: Boolean,
+        autoDelete: Boolean,
+        arguments: Table,
+    ) {
+        super.queueDeclareNoWait(name, durable, exclusive, autoDelete, arguments)
+        // A no-wait declare always carries a name, so it can never be one of the server-named queues.
+        if (restoreTopology) declaredQueues[name] = DeclaredQueue(
+            name = name,
+            durable = durable,
+            exclusive = exclusive,
+            autoDelete = autoDelete,
+            arguments = arguments
+        )
+    }
+
+    override suspend fun queueDeleteNoWait(
+        name: String,
+        ifUnused: Boolean,
+        ifEmpty: Boolean,
+    ) {
+        super.queueDeleteNoWait(name, ifUnused, ifEmpty)
+        declaredQueues.remove(name)
+        serverNamedQueues.remove(name)
+    }
+
+    override suspend fun queueBindNoWait(
+        queue: String,
+        exchange: String,
+        routingKey: String,
+        arguments: Table,
+    ) {
+        super.queueBindNoWait(queue, exchange, routingKey, arguments)
+        if (restoreTopology || queue in serverNamedQueues) {
+            boundQueues[Triple(queue, exchange, routingKey)] = BoundQueue(
+                queue = queue,
+                exchange = exchange,
+                routingKey = routingKey,
+                arguments = arguments
+            )
+        }
+    }
+
+    override suspend fun confirmSelectNoWait() {
+        super.confirmSelectNoWait()
+        confirmModeRequested = true
+    }
+
 }

--- a/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/NoWaitRestoreTest.kt
+++ b/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/NoWaitRestoreTest.kt
@@ -61,6 +61,56 @@ class NoWaitRestoreTest {
     }
 
     @Test
+    fun testNoWaitExchangeBindingsAreRecordedForRestore() = runTest {
+        withConnection({ server { restoreTopology = true } }) { connection ->
+            val channel = connection.openChannel() as RobustAMQPChannel
+            val source = "test-nowait-bound-source-${Uuid.random()}"
+            val destination = "test-nowait-bound-destination-${Uuid.random()}"
+
+            channel.exchangeDeclareNoWait(source, BuiltinExchangeType.DIRECT)
+            channel.exchangeDeclareNoWait(destination, BuiltinExchangeType.DIRECT)
+            channel.exchangeBindNoWait(destination, source, "bound.key")
+
+            assertTrue(
+                Triple(destination, source, "bound.key") in channel.boundExchanges,
+                "exchange binding not recorded for restore"
+            )
+
+            channel.exchangeUnbindNoWait(destination, source, "bound.key")
+            assertTrue(
+                Triple(destination, source, "bound.key") !in channel.boundExchanges,
+                "unbound exchange still recorded for restore"
+            )
+
+            channel.exchangeDelete(source)
+            channel.exchangeDelete(destination)
+            channel.close()
+        }
+    }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testConfirmModeSelectedWithNoWaitIsReestablishedAfterRestore() = runTest {
+        withConnection({ server { restoreTopology = false } }) { connection ->
+            val channel = connection.openChannel()
+
+            channel.confirmSelectNoWait()
+
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            reopenEvent.await()
+
+            // The reopened broker channel is not in confirm mode unless the restore re-issued the
+            // select, which only happens if the no-wait variant recorded the intent.
+            val confirm = async(start = CoroutineStart.UNDISPATCHED) { channel.publishConfirmResponses.first() }
+            channel.basicPublish("after restore".toByteArray(), "", "test-nowait-confirm-${Uuid.random()}")
+            withTimeout(5.seconds) { confirm.await() }
+
+            channel.close()
+        }
+    }
+
+    @Test
     @OptIn(DelicateCoroutinesApi::class)
     fun testTopologyDeclaredWithNoWaitSurvivesABrokerClose() = runTest {
         withConnection({ server { restoreTopology = true } }) { connection ->

--- a/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/NoWaitRestoreTest.kt
+++ b/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/NoWaitRestoreTest.kt
@@ -1,0 +1,90 @@
+package dev.kourier.amqp.robust
+
+import dev.kourier.amqp.AMQPException
+import dev.kourier.amqp.BuiltinExchangeType
+import dev.kourier.amqp.channel.AMQPChannel
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+/**
+ * Topology declared through the `no-wait` variants has to be recorded for restore exactly like the
+ * awaiting ones. Were it not, it would be missing from the replay and would silently disappear on the
+ * first reconnect, which is precisely the kind of failure the robust channel exists to prevent.
+ */
+class NoWaitRestoreTest {
+
+    private suspend fun AMQPChannel.closeByBreaking() =
+        assertFailsWith<AMQPException.ChannelClosed> {
+            exchangeDeclare(
+                "will-fail", "nonexistent-type",
+                durable = true, autoDelete = false, internal = false, arguments = emptyMap()
+            )
+        }
+
+    @Test
+    fun testNoWaitDeclarationsAreRecordedForRestore() = runTest {
+        withConnection({ server { restoreTopology = true } }) { connection ->
+            val channel = connection.openChannel() as RobustAMQPChannel
+            val exchange = "test-nowait-recorded-${Uuid.random()}"
+            val queue = "test-nowait-recorded-queue-${Uuid.random()}"
+
+            channel.exchangeDeclareNoWait(exchange, BuiltinExchangeType.TOPIC)
+            channel.queueDeclareNoWait(queue, durable = false, exclusive = false, autoDelete = true)
+            channel.queueBindNoWait(queue, exchange, "recorded.key")
+
+            assertTrue(exchange in channel.declaredExchanges, "exchange not recorded for restore")
+            assertTrue(queue in channel.declaredQueues, "queue not recorded for restore")
+            assertTrue(
+                Triple(queue, exchange, "recorded.key") in channel.boundQueues,
+                "binding not recorded for restore"
+            )
+
+            channel.queueDeleteNoWait(queue)
+            assertTrue(queue !in channel.declaredQueues, "deleted queue still recorded for restore")
+
+            channel.exchangeDeleteNoWait(exchange)
+            assertTrue(exchange !in channel.declaredExchanges, "deleted exchange still recorded for restore")
+
+            channel.close()
+        }
+    }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testTopologyDeclaredWithNoWaitSurvivesABrokerClose() = runTest {
+        withConnection({ server { restoreTopology = true } }) { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-nowait-restore-${Uuid.random()}"
+            val queue = "test-nowait-restore-queue-${Uuid.random()}"
+
+            channel.exchangeDeclareNoWait(exchange, BuiltinExchangeType.TOPIC)
+            // autoDelete so the broker drops the queue when the channel close cancels its consumer:
+            // the restore then has to re-declare and re-bind it rather than finding it still there.
+            channel.queueDeclareNoWait(queue, durable = false, exclusive = false, autoDelete = true)
+            channel.queueBindNoWait(queue, exchange, "restore.key")
+            val deliveries = channel.basicConsume(queue = queue, noAck = true)
+
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            reopenEvent.await()
+
+            channel.basicPublish("after restore".toByteArray(), exchange, "restore.key")
+            val delivery = withTimeout(5.seconds) { deliveries.receive() }
+            assertEquals("after restore", delivery.message.body.decodeToString())
+
+            channel.exchangeDelete(exchange)
+            channel.close()
+        }
+    }
+}

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/AMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/AMQPChannel.kt
@@ -513,4 +513,154 @@ interface AMQPChannel {
      */
     suspend fun txRollback(): AMQPResponse.Channel.Tx.Rollbacked
 
+    // No-wait variants.
+    //
+    // Each of these sends the same frame as its regular counterpart but with the protocol's `no-wait`
+    // flag set, so the broker sends no reply and the call returns as soon as the frame is written.
+    // Declaring a large topology this way costs one round trip instead of one per declaration.
+    //
+    // The trade-off is that failures no longer surface as a returned error: the broker reports them by
+    // closing the channel, so they arrive asynchronously as an [AMQPException.ChannelClosed] on the
+    // next operation. Use the regular variants when you need to act on the outcome of each call.
+
+    /**
+     * Declares a queue without waiting for the broker to confirm it.
+     *
+     * @param name Name of the queue. Unlike [queueDeclare], it cannot be empty: with no reply there is
+     *             no way to learn the name the broker would have generated.
+     * @param durable If enabled, creates a queue stored on disk; otherwise, transient.
+     * @param exclusive Announces the queue as exclusive to this connection.
+     * @param autoDelete Announces the queue as auto-deleted once its last consumer leaves.
+     * @param arguments Additional arguments (check RabbitMQ documentation).
+     *
+     * @throws IllegalArgumentException if [name] is blank.
+     */
+    suspend fun queueDeclareNoWait(
+        name: String,
+        durable: Boolean = false,
+        exclusive: Boolean = false,
+        autoDelete: Boolean = false,
+        arguments: Table = emptyMap(),
+    )
+
+    /**
+     * Passively declares a queue without waiting for the broker to confirm it.
+     *
+     * Since nothing is returned, this asserts the queue exists rather than reading its state: if it
+     * does not, the broker closes the channel.
+     *
+     * @param name Name of the queue.
+     */
+    suspend fun queueDeclarePassiveNoWait(name: String)
+
+    /**
+     * Deletes a queue without waiting for the broker to confirm it.
+     *
+     * @param name Name of the queue.
+     * @param ifUnused If enabled, queue will only be deleted if it has no consumers.
+     * @param ifEmpty If enabled, queue will only be deleted if it has no messages.
+     */
+    suspend fun queueDeleteNoWait(
+        name: String,
+        ifUnused: Boolean = false,
+        ifEmpty: Boolean = false,
+    )
+
+    /**
+     * Purges a queue without waiting for the broker to confirm it.
+     *
+     * @param name Name of the queue.
+     */
+    suspend fun queuePurgeNoWait(name: String)
+
+    /**
+     * Binds a queue to an exchange without waiting for the broker to confirm it.
+     *
+     * @param queue Name of the queue.
+     * @param exchange Name of the exchange.
+     * @param routingKey Bind only to messages matching routingKey.
+     * @param arguments Bind only to messages matching given options.
+     */
+    suspend fun queueBindNoWait(
+        queue: String,
+        exchange: String,
+        routingKey: String = "",
+        arguments: Table = emptyMap(),
+    )
+
+    /**
+     * Declares an exchange without waiting for the broker to confirm it.
+     *
+     * @param name Name of the exchange.
+     * @param type Type of the exchange.
+     * @param durable If enabled, creates an exchange stored on disk; otherwise, transient.
+     * @param autoDelete If enabled, exchange is deleted when the last binding is removed.
+     * @param internal Whether the exchange cannot be directly published to by a client.
+     * @param arguments Additional arguments (check RabbitMQ documentation).
+     */
+    suspend fun exchangeDeclareNoWait(
+        name: String,
+        type: String,
+        durable: Boolean = false,
+        autoDelete: Boolean = false,
+        internal: Boolean = false,
+        arguments: Table = emptyMap(),
+    )
+
+    /**
+     * Passively declares an exchange without waiting for the broker to confirm it.
+     *
+     * Since nothing is returned, this asserts the exchange exists rather than reading its state: if it
+     * does not, the broker closes the channel.
+     *
+     * @param name Name of the exchange.
+     */
+    suspend fun exchangeDeclarePassiveNoWait(name: String)
+
+    /**
+     * Deletes an exchange without waiting for the broker to confirm it.
+     *
+     * @param name Name of the exchange.
+     * @param ifUnused If enabled, exchange will be deleted only if it has no bindings.
+     */
+    suspend fun exchangeDeleteNoWait(name: String, ifUnused: Boolean = false)
+
+    /**
+     * Binds an exchange to another exchange without waiting for the broker to confirm it.
+     *
+     * @param destination Name of the destination exchange.
+     * @param source Name of the source exchange.
+     * @param routingKey Bind only to messages matching routingKey.
+     * @param arguments Bind only to messages matching given options.
+     */
+    suspend fun exchangeBindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: Table = emptyMap(),
+    )
+
+    /**
+     * Unbinds an exchange from another exchange without waiting for the broker to confirm it.
+     *
+     * @param destination Name of the destination exchange.
+     * @param source Name of the source exchange.
+     * @param routingKey Unbind only from messages matching routingKey.
+     * @param arguments Unbind only from messages matching given options.
+     */
+    suspend fun exchangeUnbindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: Table = emptyMap(),
+    )
+
+    /**
+     * Puts the channel in publish confirm mode without waiting for the broker to confirm it.
+     *
+     * Frames are processed in order on a channel, so publishes issued after this call are covered by
+     * confirm mode even though the `Confirm.SelectOk` was never awaited.
+     */
+    suspend fun confirmSelectNoWait()
+
 }

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
@@ -824,4 +824,218 @@ open class DefaultAMQPChannel(
         return writeAndWaitForResponse(rollback)
     }
 
+    // No-wait variants: same frame with `noWait = true`, written without awaiting a reply.
+
+    override suspend fun queueDeclareNoWait(
+        name: String,
+        durable: Boolean,
+        exclusive: Boolean,
+        autoDelete: Boolean,
+        arguments: Table,
+    ) {
+        require(name.isNotBlank()) {
+            "queueDeclareNoWait requires a queue name: with no reply, a server-generated one could never be read back"
+        }
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Queue.Declare(
+                    reserved1 = 0u,
+                    queueName = name,
+                    passive = false,
+                    durable = durable,
+                    exclusive = exclusive,
+                    autoDelete = autoDelete,
+                    noWait = true,
+                    arguments = arguments
+                )
+            )
+        )
+    }
+
+    override suspend fun queueDeclarePassiveNoWait(name: String) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Queue.Declare(
+                    reserved1 = 0u,
+                    queueName = name,
+                    passive = true,
+                    durable = false,
+                    exclusive = true,
+                    autoDelete = true,
+                    noWait = true,
+                    arguments = emptyMap()
+                )
+            )
+        )
+    }
+
+    override suspend fun queueDeleteNoWait(
+        name: String,
+        ifUnused: Boolean,
+        ifEmpty: Boolean,
+    ) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Queue.Delete(
+                    reserved1 = 0u,
+                    queueName = name,
+                    ifUnused = ifUnused,
+                    ifEmpty = ifEmpty,
+                    noWait = true
+                )
+            )
+        )
+    }
+
+    override suspend fun queuePurgeNoWait(name: String) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Queue.Purge(
+                    reserved1 = 0u,
+                    queueName = name,
+                    noWait = true
+                )
+            )
+        )
+    }
+
+    override suspend fun queueBindNoWait(
+        queue: String,
+        exchange: String,
+        routingKey: String,
+        arguments: Table,
+    ) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Queue.Bind(
+                    reserved1 = 0u,
+                    queueName = queue,
+                    exchangeName = exchange,
+                    routingKey = routingKey,
+                    noWait = true,
+                    arguments = arguments
+                )
+            )
+        )
+    }
+
+    override suspend fun exchangeDeclareNoWait(
+        name: String,
+        type: String,
+        durable: Boolean,
+        autoDelete: Boolean,
+        internal: Boolean,
+        arguments: Table,
+    ) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Exchange.Declare(
+                    reserved1 = 0u,
+                    exchangeName = name,
+                    exchangeType = type,
+                    passive = false,
+                    durable = durable,
+                    autoDelete = autoDelete,
+                    internal = internal,
+                    noWait = true,
+                    arguments = arguments
+                )
+            )
+        )
+    }
+
+    override suspend fun exchangeDeclarePassiveNoWait(name: String) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Exchange.Declare(
+                    reserved1 = 0u,
+                    exchangeName = name,
+                    exchangeType = "",
+                    passive = true,
+                    durable = false,
+                    autoDelete = false,
+                    internal = false,
+                    noWait = true,
+                    arguments = emptyMap()
+                )
+            )
+        )
+    }
+
+    override suspend fun exchangeDeleteNoWait(name: String, ifUnused: Boolean) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Exchange.Delete(
+                    reserved1 = 0u,
+                    exchangeName = name,
+                    ifUnused = ifUnused,
+                    noWait = true
+                )
+            )
+        )
+    }
+
+    override suspend fun exchangeBindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: Table,
+    ) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Exchange.Bind(
+                    reserved1 = 0u,
+                    destination = destination,
+                    source = source,
+                    routingKey = routingKey,
+                    noWait = true,
+                    arguments = arguments
+                )
+            )
+        )
+    }
+
+    override suspend fun exchangeUnbindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: Table,
+    ) {
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Exchange.Unbind(
+                    reserved1 = 0u,
+                    destination = destination,
+                    source = source,
+                    routingKey = routingKey,
+                    noWait = true,
+                    arguments = arguments
+                )
+            )
+        )
+    }
+
+    override suspend fun confirmSelectNoWait() {
+        if (isConfirmMode) return
+        write(
+            Frame(
+                channelId = id,
+                payload = Frame.Method.Confirm.Select(
+                    noWait = true
+                )
+            )
+        )
+        isConfirmMode = true
+    }
+
 }

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/AMQPChannelsConcurrencyTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/AMQPChannelsConcurrencyTest.kt
@@ -193,4 +193,50 @@ private class StubChannel(override val id: dev.kourier.amqp.ChannelId) : AMQPCha
     override suspend fun txSelect() = error("not used")
     override suspend fun txCommit() = error("not used")
     override suspend fun txRollback() = error("not used")
+
+    override suspend fun queueDeclareNoWait(
+        name: String,
+        durable: Boolean,
+        exclusive: Boolean,
+        autoDelete: Boolean,
+        arguments: dev.kourier.amqp.Table,
+    ) = error("not used")
+
+    override suspend fun queueDeclarePassiveNoWait(name: String) = error("not used")
+    override suspend fun queueDeleteNoWait(name: String, ifUnused: Boolean, ifEmpty: Boolean) = error("not used")
+    override suspend fun queuePurgeNoWait(name: String) = error("not used")
+    override suspend fun queueBindNoWait(
+        queue: String,
+        exchange: String,
+        routingKey: String,
+        arguments: dev.kourier.amqp.Table,
+    ) = error("not used")
+
+    override suspend fun exchangeDeclareNoWait(
+        name: String,
+        type: String,
+        durable: Boolean,
+        autoDelete: Boolean,
+        internal: Boolean,
+        arguments: dev.kourier.amqp.Table,
+    ) = error("not used")
+
+    override suspend fun exchangeDeclarePassiveNoWait(name: String) = error("not used")
+    override suspend fun exchangeDeleteNoWait(name: String, ifUnused: Boolean) = error("not used")
+    override suspend fun exchangeBindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: dev.kourier.amqp.Table,
+    ) = error("not used")
+
+    override suspend fun exchangeUnbindNoWait(
+        destination: String,
+        source: String,
+        routingKey: String,
+        arguments: dev.kourier.amqp.Table,
+    ) = error("not used")
+
+    override suspend fun confirmSelectNoWait() = error("not used")
+
 }

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/NoWaitTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/NoWaitTest.kt
@@ -120,6 +120,65 @@ class NoWaitTest {
     }
 
     @Test
+    fun testQueueDeclarePassiveNoWaitAssertsExistence() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queue = "test-nowait-passive-queue-${Uuid.random()}"
+
+            channel.queueDeclare(queue, durable = false, exclusive = true, autoDelete = true)
+            channel.queueDeclarePassiveNoWait(queue)
+
+            // The assertion held, so the channel is still alive and usable.
+            assertEquals(queue, channel.queueDeclarePassive(queue).queueName)
+
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testQueueDeclarePassiveNoWaitClosesTheChannelWhenTheQueueIsMissing() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+
+            channel.queueDeclarePassiveNoWait("test-nowait-absent-${Uuid.random()}")
+
+            // Nothing is returned, so the failed assertion reaches us only as the broker closing the
+            // channel. Awaiting that signal is deterministic, unlike issuing another call and hoping
+            // it is rejected rather than left waiting for a reply that will never come.
+            val closed = withTimeout(5.seconds) { channel.channelClosed.await() }
+            assertEquals(404u.toUShort(), closed.replyCode)
+        }
+    }
+
+    @Test
+    fun testExchangeDeclarePassiveNoWaitAssertsExistence() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-nowait-passive-exchange-${Uuid.random()}"
+
+            channel.exchangeDeclare(exchange, BuiltinExchangeType.DIRECT)
+            channel.exchangeDeclarePassiveNoWait(exchange)
+
+            channel.exchangeDeclarePassive(exchange)
+
+            channel.exchangeDelete(exchange)
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testExchangeDeclarePassiveNoWaitClosesTheChannelWhenTheExchangeIsMissing() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+
+            channel.exchangeDeclarePassiveNoWait("test-nowait-absent-${Uuid.random()}")
+
+            val closed = withTimeout(5.seconds) { channel.channelClosed.await() }
+            assertEquals(404u.toUShort(), closed.replyCode)
+        }
+    }
+
+    @Test
     fun testExchangeBindAndUnbindNoWait() = runTest {
         withConnection { connection ->
             val channel = connection.openChannel()

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/NoWaitTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/NoWaitTest.kt
@@ -1,0 +1,168 @@
+package dev.kourier.amqp.channel
+
+import dev.kourier.amqp.AMQPException
+import dev.kourier.amqp.BuiltinExchangeType
+import dev.kourier.amqp.withConnection
+import io.ktor.utils.io.core.*
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+/**
+ * Covers the `no-wait` variants: the broker sends no reply, so each test checks the effect through an
+ * awaiting call afterwards rather than through a return value.
+ */
+class NoWaitTest {
+
+    @Test
+    fun testQueueDeclareNoWaitCreatesTheQueue() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queue = "test-nowait-declare-${Uuid.random()}"
+
+            channel.queueDeclareNoWait(queue, durable = false, exclusive = true, autoDelete = true)
+
+            // A passive declare only succeeds if the queue is really there.
+            assertEquals(queue, channel.queueDeclarePassive(queue).queueName)
+
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testQueueDeclareNoWaitRejectsAnEmptyName() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+
+            // With no reply there is no way to learn a server-generated name, so asking for one is a
+            // programming error rather than something to discover at runtime.
+            assertFailsWith<IllegalArgumentException> { channel.queueDeclareNoWait("") }
+
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testQueueBindNoWaitRoutesMessages() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-nowait-bind-${Uuid.random()}"
+            val queue = "test-nowait-bind-queue-${Uuid.random()}"
+
+            channel.exchangeDeclareNoWait(exchange, BuiltinExchangeType.TOPIC)
+            channel.queueDeclareNoWait(queue, durable = false, exclusive = true, autoDelete = true)
+            channel.queueBindNoWait(queue, exchange, "test.key")
+
+            val deliveries = channel.basicConsume(queue = queue, noAck = true)
+            channel.basicPublish("routed".toByteArray(), exchange, "test.key")
+
+            // Nothing above was acknowledged by the broker, so this delivery is the proof that the
+            // exchange, the queue and the binding all really exist.
+            assertEquals("routed", withTimeout(5.seconds) { deliveries.receive() }.message.body.decodeToString())
+
+            channel.exchangeDelete(exchange)
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testQueueDeleteNoWaitRemovesTheQueue() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queue = "test-nowait-delete-${Uuid.random()}"
+
+            channel.queueDeclare(queue, durable = false, exclusive = true, autoDelete = false)
+            channel.queueDeleteNoWait(queue)
+
+            // Passively declaring a queue that is gone raises a channel-level 404.
+            assertFailsWith<AMQPException.ChannelClosed> { channel.queueDeclarePassive(queue) }
+        }
+    }
+
+    @Test
+    fun testQueuePurgeNoWaitEmptiesTheQueue() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queue = "test-nowait-purge-${Uuid.random()}"
+
+            channel.queueDeclare(queue, durable = false, exclusive = true, autoDelete = false)
+            channel.basicPublish("to be purged".toByteArray(), "", queue)
+            channel.basicPublish("to be purged".toByteArray(), "", queue)
+
+            channel.queuePurgeNoWait(queue)
+
+            // The purge is fire and forget, but frames are ordered on a channel, so by the time this
+            // awaiting call is answered the purge has been applied.
+            assertNull(channel.basicGet(queue, noAck = true).message)
+
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testExchangeDeclareAndDeleteNoWait() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val exchange = "test-nowait-exchange-${Uuid.random()}"
+
+            channel.exchangeDeclareNoWait(exchange, BuiltinExchangeType.DIRECT)
+            // A passive declare only succeeds if the exchange is really there.
+            channel.exchangeDeclarePassive(exchange)
+
+            channel.exchangeDeleteNoWait(exchange)
+            assertFailsWith<AMQPException.ChannelClosed> { channel.exchangeDeclarePassive(exchange) }
+        }
+    }
+
+    @Test
+    fun testExchangeBindAndUnbindNoWait() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val source = "test-nowait-source-${Uuid.random()}"
+            val destination = "test-nowait-destination-${Uuid.random()}"
+            val queue = "test-nowait-chained-${Uuid.random()}"
+
+            channel.exchangeDeclareNoWait(source, BuiltinExchangeType.DIRECT)
+            channel.exchangeDeclareNoWait(destination, BuiltinExchangeType.DIRECT)
+            channel.queueDeclareNoWait(queue, durable = false, exclusive = true, autoDelete = true)
+            channel.queueBindNoWait(queue, destination, "chained")
+            channel.exchangeBindNoWait(destination, source, "chained")
+
+            val deliveries = channel.basicConsume(queue = queue, noAck = true)
+            channel.basicPublish("through".toByteArray(), source, "chained")
+            assertEquals("through", withTimeout(5.seconds) { deliveries.receive() }.message.body.decodeToString())
+
+            channel.exchangeUnbindNoWait(destination, source, "chained")
+            channel.basicPublish("dropped".toByteArray(), source, "chained")
+
+            // The unbind is applied before this awaiting call is answered, so the queue must stay empty.
+            assertNull(channel.basicGet(queue, noAck = true).message)
+
+            channel.exchangeDelete(source)
+            channel.exchangeDelete(destination)
+            channel.close()
+        }
+    }
+
+    @Test
+    fun testConfirmSelectNoWaitStillConfirmsPublishes() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+
+            channel.confirmSelectNoWait()
+
+            // Subscribe before publishing: publishConfirmResponses is a replay=0 SharedFlow. If confirm
+            // mode had not actually been applied, no Basic.Ack would come and this would time out.
+            val confirm = async(start = CoroutineStart.UNDISPATCHED) { channel.publishConfirmResponses.first() }
+            channel.basicPublish("confirmed".toByteArray(), "", "test-nowait-confirm-${Uuid.random()}")
+            withTimeout(5.seconds) { confirm.await() }
+
+            channel.close()
+        }
+    }
+}


### PR DESCRIPTION
Fixes #19.

Adds an `XNoWait` counterpart for every channel method that carries the protocol's `no-wait` flag, following the shape proposed in the issue: same frame with `noWait = true`, written with `write` instead of `writeAndWaitForResponse`.

```kotlin
// one round trip instead of one per declaration
repeat(1000) { channel.queueDeclareNoWait("queue-$it", durable = true) }
channel.queueDeclarePassive("queue-999")  // the first time we actually wait
```

## What is covered

`queueDeclare`, `queueDeclarePassive`, `queueDelete`, `queuePurge`, `queueBind`, `exchangeDeclare`, `exchangeDeclarePassive`, `exchangeDelete`, `exchangeBind`, `exchangeUnbind`, `confirmSelect`.

That is every method with a `no-wait` field except the two below. Note that `queueUnbind` has no `no-wait` in AMQP 0-9-1, so there is nothing to add there.

## What is left out, and why

**`basicConsume` and `basicCancel`.** Both keep client-side state keyed on the broker's reply:

- `basicConsume` registers its listening job under the broker-confirmed consumer tag (`listeningJobsByConsumer[result.consumerTag]`). With no reply there is no tag, so the caller would have to supply one and the registration path would need reworking.
- `basicCancel` joins the listening job after `Basic.CancelOk` so that callers observing side effects see them applied. Without the reply, the local listener has to be torn down by hand instead.

Neither is a mechanical variant, and getting them wrong would be worse than not having them, so I left them for a separate change. Happy to do it in a follow-up if you want them.

## Two decisions worth flagging

**`queueDeclareNoWait` requires a non-blank name.** `queueDeclare("")` relies on the broker replying with the generated name; with no reply that name can never be read back, so an empty name here is a programming error rather than something to discover at runtime. It throws `IllegalArgumentException`, and a test covers it.

**`RobustAMQPChannel` overrides every variant.** This is the part I would look at first in review. The robust channel records topology in its overrides so it can replay it after a reconnect. Had the no-wait variants bypassed those overrides, anything declared through them would have been absent from the restore and would have vanished on the first reconnect, silently. Each override therefore records exactly what its awaiting counterpart records, and `queueDeleteNoWait` / `exchangeDeleteNoWait` remove it again. Restore itself keeps using the awaiting variants, since it has no one to report failures to.

## Tests

`NoWaitTest` in `amqp-client`, 8 tests against a real broker. Since nothing is acknowledged, each effect is verified through an awaiting call afterwards: a passive declare proves the queue or exchange exists, a delivery proves the binding routes, `basicGet` returning nothing proves the purge and the unbind were applied, and a publish confirm proves `confirmSelectNoWait` really put the channel in confirm mode.

`NoWaitRestoreTest` in `amqp-client-robust`, 2 tests for the point above: one asserting the declarations are recorded and de-recorded, one end to end where an auto-delete queue is dropped by the broker on the channel close and the restore has to re-declare, re-bind and re-consume it before a publish can arrive.

Mutation-checked: removing the recording in `queueDeclareNoWait`'s override makes both robust tests fail, so they are load-bearing rather than decorative.

Local run on RabbitMQ 4.1, matching the CI image: `allMetadataJar` then `jvmTest koverXmlReport`, 221 tests, 0 failures.

## One side effect to be aware of

`AMQPChannel` gains 11 methods, so every implementor has to provide them. In this repo that is `DefaultAMQPChannel` and the `StubChannel` test double, both updated here. Anyone implementing the interface outside the repo would be affected too, which is worth a line in the release notes.
